### PR TITLE
Platform IO library creation

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,12 +9,16 @@
     "headers": "cmdBuffer.h",
     "dependencies":
     {
-        "external-repo": "https://github.com/hflicka/Ring-buffer-Cpp-template.git"
+        "ringBuffer": "https://github.com/hflicka/Ring-buffer-Cpp-template.git"
     },
     "export": {
         "include":
         [
             "lib/cmdBuffer/cmdBuffer.*"
+        ],
+        "exclude":
+        [
+            "lib/cmdBuffer/ringBuffer.h" 
         ]
     }
 }

--- a/library.json
+++ b/library.json
@@ -11,6 +11,12 @@
     {
         "ringBuffer": "https://github.com/hflicka/Ring-buffer-Cpp-template.git"
     },
+    "build":
+    {
+        "include": "lib/cmdBuffer",
+        "srcDir": "lib/cmdBuffer",
+        "srcFilter": "-<lib/cmdBuffer/ringBuffer.h>"
+    },
     "export": {
         "include":
         [

--- a/library.json
+++ b/library.json
@@ -1,0 +1,20 @@
+{
+    "name": "cmdBuffer",
+    "version": "1.0.0",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/bigsdawg-2k/command_buffer"
+    },
+    "headers": "cmdBuffer.h",
+    "dependencies":
+    {
+        "fastled/FastLED": "^3.4.0"
+    },
+    "export": {
+        "include":
+        [
+            "lib/cmdBuffer/cmdBuffer.*"
+        ]
+    }
+}

--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
     "headers": "cmdBuffer.h",
     "dependencies":
     {
-        "fastled/FastLED": "^3.4.0"
+        "external-repo": "https://github.com/hflicka/Ring-buffer-Cpp-template.git"
     },
     "export": {
         "include":


### PR DESCRIPTION
Can now be included into a platform IO project by adding the repository to the project using lib_deps.